### PR TITLE
hideDivider property has been replaced with border: null

### DIFF
--- a/lib/src/flutter_google_places_autocomplete.dart
+++ b/lib/src/flutter_google_places_autocomplete.dart
@@ -178,7 +178,7 @@ class _GooglePlacesAutocompleteOverlayState
         decoration: new InputDecoration(
             hintText: widget.hint,
             hintStyle: new TextStyle(color: Colors.black54, fontSize: 16.0),
-            hideDivider: true),
+            border: null),
         onChanged: _search,
       );
 }
@@ -237,7 +237,7 @@ class _GooglePlacesAutocompleteFullscreenState
         decoration: new InputDecoration(
             hintText: widget.hint,
             hintStyle: new TextStyle(color: Colors.white30, fontSize: 16.0),
-            hideDivider: true),
+            border: null),
         onChanged: _search,
       ));
 


### PR DESCRIPTION
More info here: https://github.com/flutter/flutter/pull/13734

Basically `hideDivider: true` should now be `border: null`, this change is also live in the alpha branch now so it would be a good idea to update this in your plugin.