### PR TITLE
Add PlacesAutocompleteField and respective FormField

### DIFF
--- a/lib/flutter_google_places_autocomplete.dart
+++ b/lib/flutter_google_places_autocomplete.dart
@@ -1,4 +1,7 @@
 library flutter_google_places_autocomplete;
 
-export 'src/flutter_google_places_autocomplete.dart';
 export 'package:google_maps_webservice/places.dart';
+
+export 'src/PlacesAutocompleteField.dart';
+export 'src/PlacesAutocompleteFormField.dart';
+export 'src/flutter_google_places_autocomplete.dart';

--- a/lib/src/PlacesAutocompleteField.dart
+++ b/lib/src/PlacesAutocompleteField.dart
@@ -91,7 +91,18 @@ class PlacesAutocompleteField extends StatefulWidget {
   /// extra padding introduced by the decoration to save space for the labels).
   final InputDecoration inputDecoration;
 
-  /// Min length of input for autocomplete to start.
+  /// The position, in the input term, of the last character that the service
+  /// uses to match predictions.
+  ///
+  /// For example, if the input is 'Google' and the
+  /// offset is 3, the service will match on 'Goo'. The string determined by the
+  /// offset is matched against the first word in the input term only. For
+  /// example, if the input term is 'Google abc' and the offset is 3, the service
+  /// will attempt to match against 'Goo abc'. If no offset is supplied, the
+  /// service will use the whole term. The offset should generally be set to the
+  /// position of the text caret.
+  ///
+  /// Source: https://developers.google.com/places/web-service/autocomplete
   final num offset;
 
   final Mode mode;

--- a/lib/src/PlacesAutocompleteField.dart
+++ b/lib/src/PlacesAutocompleteField.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_google_places_autocomplete/flutter_google_places_autocomplete.dart';
+
+/// A text field like widget to input places with autocomplete.
+///
+/// The autocomplete field calls [onChanged] with the new address line
+/// whenever the user input a new location.
+///
+/// To control the text that is displayed in the text field, use the
+/// [controller]. For example, to set the initial value of the text field, use
+/// a [controller] that already contains some text.
+///
+/// By default, an autocomplete field has a [decoration] that draws a divider
+/// below the field. You can use the [decoration] property to control the
+/// decoration, for example by adding a label or an icon. If you set the [decoration]
+/// property to null, the decoration will be removed entirely, including the
+/// extra padding introduced by the decoration to save space for the labels.
+/// If you want the icon to be outside the input field use [decoration.icon].
+/// If it should be inside the field use [leading].
+///
+/// To integrate the [PlacesAutocompleteField] into a [Form] with other [FormField]
+/// widgets, consider using [PlacesAutocompleteFormField].
+///
+/// See also:
+///
+///  * [PlacesAutocompleteFormField], which integrates with the [Form] widget.
+///  * [InputDecorator], which shows the labels and other visual elements that
+///    surround the actual text editing widget.
+class PlacesAutocompleteField extends StatefulWidget {
+  /// Creates a text field like widget.
+  ///
+  /// To remove the decoration entirely (including the extra padding introduced
+  /// by the decoration to save space for the labels), set the [decoration] to
+  /// null.
+  const PlacesAutocompleteField({
+    Key key,
+    @required this.apiKey,
+    this.controller,
+    this.leading,
+    this.hint = "Search",
+    this.trailing,
+    this.trailingOnTap,
+    this.mode = Mode.fullscreen,
+    this.offset,
+    this.location,
+    this.radius,
+    this.language,
+    this.types,
+    this.components,
+    this.strictbounds,
+    this.onChanged,
+    this.onError,
+    this.inputDecoration = const InputDecoration(),
+  }) : super(key: key);
+
+  /// Controls the text being edited.
+  ///
+  /// If null, this widget will create its own [TextEditingController].
+  final TextEditingController controller;
+
+  /// Icon shown inside the field left to the text.
+  final Icon leading;
+
+  /// Icon shown inside the field right to the text.
+  final Icon trailing;
+
+  /// Callback when [trailing] is tapped on.
+  final VoidCallback trailingOnTap;
+
+  /// Text that is shown, when no input was done, yet.
+  final String hint;
+
+  /// Your Google Maps Places API Key.
+  ///
+  /// For this key the Places Web API needs to be activated. For further
+  /// information on how to do this, see their official documentation below.
+  ///
+  /// See also:
+  ///
+  /// * <https://developers.google.com/places/web-service/autocomplete>
+  final String apiKey;
+
+  /// The decoration to show around the text field.
+  ///
+  /// By default, draws a horizontal line under the autocomplete field but can be
+  /// configured to show an icon, label, hint text, and error text.
+  ///
+  /// Specify null to remove the decoration entirely (including the
+  /// extra padding introduced by the decoration to save space for the labels).
+  final InputDecoration inputDecoration;
+
+  /// Min length of input for autocomplete to start.
+  final num offset;
+
+  final Mode mode;
+
+  final String language;
+
+  final List<String> types;
+
+  final List<Component> components;
+
+  final Location location;
+
+  final num radius;
+
+  final bool strictbounds;
+
+  /// Called when the text being edited changes.
+  final ValueChanged<String> onChanged;
+
+  /// Callback when autocomplete has error.
+  final ValueChanged<PlacesAutocompleteResponse> onError;
+
+  @override
+  _LocationAutocompleteFieldState createState() =>
+      new _LocationAutocompleteFieldState();
+}
+
+class _LocationAutocompleteFieldState extends State<PlacesAutocompleteField> {
+  TextEditingController _controller;
+  TextEditingController get _effectiveController =>
+      widget.controller ?? _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.controller == null) _controller = new TextEditingController();
+  }
+
+  @override
+  void didUpdateWidget(PlacesAutocompleteField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller == null && oldWidget.controller != null)
+      _controller =
+          new TextEditingController.fromValue(oldWidget.controller.value);
+    else if (widget.controller != null && oldWidget.controller == null)
+      _controller = null;
+  }
+
+  Future<Prediction> _showAutocomplete() async => showGooglePlacesAutocomplete(
+      context: context,
+      apiKey: widget.apiKey,
+      offset: widget.offset,
+      onError: widget.onError,
+      mode: widget.mode,
+      hint: widget.hint,
+      language: widget.language,
+      components: widget.components,
+      location: widget.location,
+      radius: widget.radius,
+      types: widget.types,
+      strictbounds: widget.strictbounds);
+
+  void _handleTap() async {
+    Prediction p = await _showAutocomplete();
+
+    if (p == null) return;
+
+    setState(() {
+      _effectiveController.text = p.description;
+      if (widget.onChanged != null) {
+        widget.onChanged(p.description);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TextEditingController controller = _effectiveController;
+
+    var text = controller.text.isNotEmpty
+        ? Text(
+            controller.text,
+            softWrap: true,
+          )
+        : Text(
+            widget.hint ?? '',
+            style: TextStyle(color: Colors.black38),
+          );
+
+    Widget child = Row(
+      children: <Widget>[
+        widget.leading ?? SizedBox(),
+        SizedBox(
+          width: 16.0,
+        ),
+        Expanded(
+          child: text,
+        ),
+        widget.trailing != null
+            ? GestureDetector(
+                onTap: widget.trailingOnTap,
+                child: widget.trailingOnTap != null
+                    ? widget.trailing
+                    : Icon(
+                        widget.trailing.icon,
+                        color: Colors.grey,
+                      ),
+              )
+            : SizedBox()
+      ],
+    );
+
+    if (widget.inputDecoration != null) {
+      child = InputDecorator(
+        decoration: widget.inputDecoration,
+        child: child,
+      );
+    }
+
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: _handleTap,
+      child: child,
+    );
+  }
+}

--- a/lib/src/PlacesAutocompleteFormField.dart
+++ b/lib/src/PlacesAutocompleteFormField.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_google_places_autocomplete/flutter_google_places_autocomplete.dart';
+
+import 'PlacesAutocompleteField.dart';
+
+/// A [FormField] that contains a [PlacesAutocompleteField].
+///
+/// This is a convenience widget that wraps a [PlacesAutocompleteField] widget in a
+/// [FormField].
+///
+/// A [Form] ancestor is not required. The [Form] simply makes it easier to
+/// save, reset, or validate multiple fields at once. To use without a [Form],
+/// pass a [GlobalKey] to the constructor and use [GlobalKey.currentState] to
+/// save or reset the form field.
+///
+/// When a [controller] is specified, its [TextEditingController.text]
+/// defines the [initialValue]. If this [FormField] is part of a scrolling
+/// container that lazily constructs its children, like a [ListView] or a
+/// [CustomScrollView], then a [controller] should be specified.
+/// The controller's lifetime should be managed by a stateful widget ancestor
+/// of the scrolling container.
+///
+/// If a [controller] is not specified, [initialValue] can be used to give
+/// the automatically generated controller an initial value.
+///
+/// For a documentation about the various parameters, see [PlacesAutocompleteField].
+///
+/// See also:
+///
+///  * [PlacesAutocompleteField], which is the underlying widget without the [Form]
+///    integration.
+///  * [InputDecorator], which shows the labels and other visual elements that
+///    surround the actual text editing widget.
+class PlacesAutocompleteFormField extends FormField<String> {
+  /// Creates a [FormField] that contains a [PlacesAutocompleteField].
+  ///
+  /// When a [controller] is specified, [initialValue] must be null (the
+  /// default). If [controller] is null, then a [TextEditingController]
+  /// will be constructed automatically and its `text` will be initialized
+  /// to [initalValue] or the empty string.
+  ///
+  /// For documentation about the various parameters, see the [PlacesAutocompleteField] class
+  /// and [new PlacesAutocompleteField], the constructor.
+  PlacesAutocompleteFormField({
+    Key key,
+    @required String apiKey,
+    this.controller,
+    Icon leading,
+    String initialValue,
+    String hint = "Search",
+    Icon trailing,
+    VoidCallback trailingOnTap,
+    Mode mode = Mode.fullscreen,
+    num offset,
+    Location location,
+    num radius,
+    String language,
+    List<String> types,
+    List<Component> components,
+    bool strictbounds,
+    ValueChanged<PlacesAutocompleteResponse> onError,
+    InputDecoration inputDecoration = const InputDecoration(),
+    bool autovalidate = false,
+    FormFieldSetter<String> onSaved,
+    FormFieldValidator<String> validator,
+  })  : assert(initialValue == null || controller == null),
+        super(
+          key: key,
+          initialValue:
+              controller != null ? controller.text : (initialValue ?? ''),
+          onSaved: onSaved,
+          validator: validator,
+          autovalidate: autovalidate,
+          builder: (FormFieldState<String> field) {
+            final _TextFormFieldState state = field;
+            final InputDecoration effectiveDecoration = inputDecoration
+                ?.applyDefaults(Theme.of(state.context).inputDecorationTheme);
+            return PlacesAutocompleteField(
+              key: key,
+              inputDecoration:
+                  effectiveDecoration?.copyWith(errorText: state.errorText),
+              controller: state._effectiveController,
+              apiKey: apiKey,
+              leading: leading,
+              trailing: trailing,
+              offset: offset,
+              trailingOnTap: trailingOnTap,
+              hint: hint,
+              location: location,
+              radius: radius,
+              components: components,
+              language: language,
+              types: types,
+              mode: mode,
+              strictbounds: strictbounds,
+              onChanged: state.didChange,
+              onError: onError,
+            );
+          },
+        );
+
+  /// Controls the text being edited.
+  ///
+  /// If null, this widget will create its own [TextEditingController] and
+  /// initialize its [TextEditingController.text] with [initialValue].
+  final TextEditingController controller;
+
+  @override
+  _TextFormFieldState createState() => new _TextFormFieldState();
+}
+
+class _TextFormFieldState extends FormFieldState<String> {
+  TextEditingController _controller;
+
+  TextEditingController get _effectiveController =>
+      widget.controller ?? _controller;
+
+  @override
+  PlacesAutocompleteFormField get widget => super.widget;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.controller == null) {
+      _controller = new TextEditingController(text: widget.initialValue);
+    } else {
+      widget.controller.addListener(_handleControllerChanged);
+    }
+  }
+
+  @override
+  void didUpdateWidget(PlacesAutocompleteFormField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller?.removeListener(_handleControllerChanged);
+      widget.controller?.addListener(_handleControllerChanged);
+
+      if (oldWidget.controller != null && widget.controller == null)
+        _controller =
+            new TextEditingController.fromValue(oldWidget.controller.value);
+      if (widget.controller != null) {
+        setValue(widget.controller.text);
+        if (oldWidget.controller == null) _controller = null;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.removeListener(_handleControllerChanged);
+    super.dispose();
+  }
+
+  @override
+  void reset() {
+    super.reset();
+    setState(() {
+      _effectiveController.text = widget.initialValue;
+    });
+  }
+
+  void _handleControllerChanged() {
+    // Suppress changes that originated from within this class.
+    //
+    // In the case where a controller has been passed in to this widget, we
+    // register this change listener. In these cases, we'll also receive change
+    // notifications for changes originating from within this class -- for
+    // example, the reset() method. In such cases, the FormField value will
+    // already have been set.
+    if (_effectiveController.text != value)
+      didChange(_effectiveController.text);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_autocomplete
 description: Google places autocomplete widgets for flutter. No wrapper, use https://pub.dartlang.org/packages/google_maps_webservice
-version: 0.1.1+1
+version: 0.1.2
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 homepage: https://github.com/lejard-h/flutter_google_places_autocomplete
 


### PR DESCRIPTION
I created two flutter widgets to integrate the autocomplete functionality in a text field like input field. I thought it may be of use to other developers as well.

Example usage:
```dart
PlacesAutocompleteFormField(
    leading: Icon(Icons.flag),
    hint: "Where do you want to go?",
    mode: Mode.overlay,
    language: "en",
    components: [new Component(Component.country, "at")],
    offset: 2,
    controller: _destLocationController,
    apiKey: GOOGLE_MAPS_API_KEY,
    inputDecoration: InputDecoration(border: OutlineInputBorder()),
    trailing: Icon(Icons.swap_vert),
    trailingOnTap: _swapStartDest,
    validator: (String value) =>
        value.isEmpty ? "Plaese, tell me where you want to go." : null,
    onSaved: (String value) => destination = value,
    onError: (res) {
        print(res.errorMessage);
    },
);
```